### PR TITLE
Version prefix

### DIFF
--- a/concent-builder/build.yml
+++ b/concent-builder/build.yml
@@ -40,9 +40,11 @@
             chdir: "{{ build_dir }}/concent-deployment/containers"
             params:
               CONCENT_SECRET_DIR: "{{ data_dir }}/concent-secrets"
+              IMAGE_PREFIX:       "{{ image_prefix }}"
 
         - name: Build cluster configuration
           make:
             chdir: "{{ build_dir }}/concent-deployment/kubernetes"
             params:
               CONCENT_SECRET_DIR: "{{ data_dir }}/concent-secrets"
+              IMAGE_PREFIX:       "{{ image_prefix }}"

--- a/containers/Makefile
+++ b/containers/Makefile
@@ -1,4 +1,3 @@
-VERSION := 1.0.0
 NGINX_PROXY_SOURCE :=               \
     build/nginx-proxy/Dockerfile    \
     build/nginx-proxy/index.html    \
@@ -21,30 +20,41 @@ ifndef CONCENT_DIR
 endif
 $(info CONCENT_DIR=$(CONCENT_DIR))
 
+ifndef IMAGE_VERSION
+	IMAGE_VERSION := $(shell git describe --always)
+endif
+$(info IMAGE_VERSION=$(IMAGE_VERSION))
+
+ifndef IMAGE_PREFIX
+	IMAGE_PREFIX :=
+endif
+$(info IMAGE_PREFIX=$(IMAGE_PREFIX))
+
+
 all: build/ nginx-proxy concent-api postgresql
 
 nginx-proxy: $(NGINX_PROXY_SOURCE) build/nginx-proxy/concent-api-assets.tar build/nginx-proxy/concent-api-docs.tar
-	docker build -t nginx-proxy:$(VERSION) build/nginx-proxy/
-	docker tag nginx-proxy:$(VERSION) nginx-proxy:latest
+	docker build -t $(IMAGE_PREFIX)nginx-proxy:$(IMAGE_VERSION) build/nginx-proxy/
+	docker tag $(IMAGE_PREFIX)nginx-proxy:$(IMAGE_VERSION) $(IMAGE_PREFIX)nginx-proxy:latest
 
 postgresql: $(POSTGRESQL_SOURCE)
-	docker build -t postgresql:$(VERSION) build/postgresql/
-	docker tag postgresql:$(VERSION) postgresql:latest
+	docker build -t $(IMAGE_PREFIX)postgresql:$(IMAGE_VERSION) build/postgresql/
+	docker tag $(IMAGE_PREFIX)postgresql:$(IMAGE_VERSION) $(IMAGE_PREFIX)postgresql:latest
 
 concent-api: $(CONCENT_API_SOURCE) build/concent-api/concent-api.tar
-	docker build -t concent-api:$(VERSION) build/concent-api/
-	docker tag concent-api:$(VERSION) concent-api:latest
+	docker build -t $(IMAGE_PREFIX)concent-api:$(IMAGE_VERSION) build/concent-api/
+	docker tag $(IMAGE_PREFIX)concent-api:$(IMAGE_VERSION) $(IMAGE_PREFIX)concent-api:latest
 
 docker-clean: nginx-proxy-clean concent-api-clean postgresql-clean
 
 nginx-proxy-clean:
-	docker rmi nginx-proxy:$(VERSION) --force
+	docker rmi $(IMAGE_PREFIX)nginx-proxy:$(IMAGE_VERSION) --force
 
 postgresql-clean:
-	docker rmi postgresql:$(VERSION) --force
+	docker rmi $(IMAGE_PREFIX)postgresql:$(IMAGE_VERSION) --force
 
 concent-api-clean:
-	docker rmi concent-api:$(VERSION) --force
+	docker rmi $(IMAGE_PREFIX)concent-api:$(IMAGE_VERSION) --force
 
 build/concent-api/concent-api.tar: $(CONCENT_DIR)
 	mkdir --parents $(dir $@)

--- a/kubernetes/Makefile
+++ b/kubernetes/Makefile
@@ -21,9 +21,15 @@ CLUSTER_SCRIPTS :=                                     \
 	build/jobs/delete-database.yml
 
 ifndef CONCENT_SECRET_DIR
-	CONCENT_SECRET_DIR:= $(abspath ../../concent-secrets)
+	CONCENT_SECRET_DIR := $(abspath ../../concent-secrets)
 endif
 $(info CONCENT_SECRET_DIR=$(CONCENT_SECRET_DIR))
+
+ifndef IMAGE_VERSION
+	IMAGE_VERSION := "latest"
+endif
+$(info IMAGE_VERSION=$(IMAGE_VERSION))
+
 
 all: cluster-scripts
 
@@ -46,9 +52,11 @@ build/concent-secrets/%: $(CONCENT_SECRET_DIR)/%
 build/%: %.j2 build/vars-merged-with-secrets.yml ../tools/render-jinja-template.sh
 	../tools/render-jinja-template.sh build/vars-merged-with-secrets.yml "$<" "$@"
 
-build/vars-merged-with-secrets.yml: var.yml $(CONCENT_SECRET_DIR)/var-secret.yml ../tools/merge-yaml.py
-	../tools/merge-yaml.py "$<" $(CONCENT_SECRET_DIR)/var-secret.yml --output "$@"
+build/vars-merged-with-secrets.yml: var.yml $(CONCENT_SECRET_DIR)/var-secret.yml build/image-version.yml ../tools/merge-yaml.py
+	../tools/merge-yaml.py "$<" $(CONCENT_SECRET_DIR)/var-secret.yml build/image-version.yml --output "$@"
 
+build/image-version.yml:
+	echo "image_version: $(IMAGE_VERSION)" >> build/image-version.yml
 
 clean:
 	rm -rf build/

--- a/kubernetes/jobs/create-database.yml.j2
+++ b/kubernetes/jobs/create-database.yml.j2
@@ -29,7 +29,7 @@ spec:
             name: concent-api-settings
       initContainers:
         - name:             create-database
-          image:            {{ docker_registry }}/postgresql:latest
+          image:            {{ docker_registry }}/{{ image_prefix }}postgresql:{{ image_version }}
           imagePullPolicy:  Always
           command:          ["/usr/local/bin/create-database.sh", "{{ database_host }}", "{{ database_name }}", "{{ database_user }}"]
           env:
@@ -44,7 +44,7 @@ spec:
                   name: db-secrets
                   key:  db_user_password
         - name:             migrate-database
-          image:            {{ docker_registry }}/concent-api:latest
+          image:            {{ docker_registry }}/{{ image_prefix }}concent-api:{{ image_version }}
           imagePullPolicy:  Always
           command:          ["/usr/local/bin/concent-api-manage.sh", "migrate"]
           volumeMounts:
@@ -55,7 +55,7 @@ spec:
               mountPath:  /srv/http/concent_api/concent_api/settings/config_map/
               readOnly:   true
         - name:             create-django-admin
-          image:            {{ docker_registry }}/concent-api:latest
+          image:            {{ docker_registry }}/{{ image_prefix }}concent-api:{{ image_version }}
           imagePullPolicy:  Always
           command:          ["/usr/local/bin/concent-api-manage.sh", "loaddata", "/srv/http/fixtures/django-admin-fixture.yaml"]
           volumeMounts:

--- a/kubernetes/jobs/delete-database.yml.j2
+++ b/kubernetes/jobs/delete-database.yml.j2
@@ -20,7 +20,7 @@ spec:
             defaultMode: 0600
       initContainers:
         - name:             delete-database
-          image:            {{ docker_registry }}/postgresql:latest
+          image:            {{ docker_registry }}/{{ image_prefix }}postgresql:{{ image_version }}
           imagePullPolicy:  Always
           command:          ["/usr/local/bin/delete-database.sh", "{{ database_host }}", "{{ database_name }}", "{{ database_user }}"]
           env:

--- a/kubernetes/jobs/migrate-database.yml.j2
+++ b/kubernetes/jobs/migrate-database.yml.j2
@@ -22,7 +22,7 @@ spec:
             name: concent-api-settings
       initContainers:
         - name:             migrate-database
-          image:            {{ docker_registry }}/concent-api:latest
+          image:            {{ docker_registry }}/{{ image_prefix }}concent-api:{{ image_version }}
           imagePullPolicy:  Always
           command:          ["/usr/local/bin/concent-api-manage.sh", "migrate"]
           volumeMounts:

--- a/kubernetes/push-docker-images.sh.j2
+++ b/kubernetes/push-docker-images.sh.j2
@@ -1,9 +1,9 @@
 #!/bin/bash -e
 
-docker tag nginx-proxy:latest {{ docker_registry }}/nginx-proxy:latest
-docker tag concent-api:latest {{ docker_registry }}/concent-api:latest
-docker tag postgresql:latest  {{ docker_registry }}/postgresql:latest
+docker tag {{ image_prefix }}nginx-proxy:{{ image_version }} {{ docker_registry }}/{{ image_prefix }}nginx-proxy:{{ image_version }}
+docker tag {{ image_prefix }}concent-api:{{ image_version }} {{ docker_registry }}/{{ image_prefix }}concent-api:{{ image_version }}
+docker tag {{ image_prefix }}postgresql:{{ image_version }}  {{ docker_registry }}/{{ image_prefix }}postgresql:{{ image_version }}
 
-gcloud docker -- push {{ docker_registry }}/nginx-proxy:latest
-gcloud docker -- push {{ docker_registry }}/concent-api:latest
-gcloud docker -- push {{ docker_registry }}/postgresql:latest
+gcloud docker -- push {{ docker_registry }}/{{ image_prefix }}nginx-proxy:{{ image_version }}
+gcloud docker -- push {{ docker_registry }}/{{ image_prefix }}concent-api:{{ image_version }}
+gcloud docker -- push {{ docker_registry }}/{{ image_prefix }}postgresql:{{ image_version }}

--- a/kubernetes/services/concent-api.yml.j2
+++ b/kubernetes/services/concent-api.yml.j2
@@ -12,7 +12,7 @@ spec:
     spec:
       containers:
         - name:             concent-api
-          image:            {{ docker_registry }}/concent-api:latest
+          image:            {{ docker_registry }}/{{image_prefix }}concent-api:{{ image_version }}
           imagePullPolicy:  Always
           ports:
             - containerPort: 80

--- a/kubernetes/services/nginx-proxy.yml.j2
+++ b/kubernetes/services/nginx-proxy.yml.j2
@@ -11,7 +11,7 @@ spec:
         run: nginx-proxy
     spec:
       containers:
-        - image:           {{ docker_registry }}/nginx-proxy:latest
+        - image:           {{ docker_registry }}/{{ image_prefix }}nginx-proxy:{{ image_version }}
           name:            nginx
           imagePullPolicy: Always
           resources:


### PR DESCRIPTION
Pull request for #4.

@cameel 
I tested it at cluster with a positive result. 
Docker images created with "concent-" part with image version as tag. 
Valid and up - to date branches are: **version-prefix** at concent-deployment  repository and var-file at **concent-deployment-values** repository.