### PR TITLE
Add version of nginx-storage to fix a problem with libcrypto in newest version of openresty

### DIFF
--- a/containers/nginx-storage/Dockerfile
+++ b/containers/nginx-storage/Dockerfile
@@ -1,4 +1,4 @@
-FROM openresty/openresty:alpine-fat
+FROM openresty/openresty:1.13.6.1-1-alpine-fat
 
 COPY install-dependencies.sh /tmp/
 RUN /tmp/install-dependencies.sh


### PR DESCRIPTION
Adding `nginx-big-upload` module to the latest version of `openresty` has some problem with `libcrypto` lib, so we add a version that work without problem.