### PR TITLE
Add version of geth to fix a problem with changing user to non-privileged user

### DIFF
--- a/kubernetes/services/geth.yml.j2
+++ b/kubernetes/services/geth.yml.j2
@@ -12,7 +12,7 @@ spec:
     spec:
       containers:
         - name:             geth
-          image:            ethereum/client-go
+          image:            ethereum/client-go:v1.8.3
           imagePullPolicy:  Always
           args:             [
               "--rinkeby",


### PR DESCRIPTION
Newest version of geth change user from root to non-privileged user.
This causes a problem with permissions to persistent disk.