### PR TITLE
Change generate RELEASE-VERSION from concent-deployment repository to concent repository

### DIFF
--- a/containers/package-builder/build-concent-api.sh
+++ b/containers/package-builder/build-concent-api.sh
@@ -3,9 +3,12 @@
 concent_dir=$1
 output_dir=$2
 
-build/virtualenv/bin/python3 "build/virtualenv/src/golem-messages/version.py"
-mv RELEASE-VERSION "$concent_dir"
+deployment_dir="../concent-deployment/containers"
 
+cd "$concent_dir/"
+"$deployment_dir/build/virtualenv/bin/python3" "$deployment_dir/build/virtualenv/src/golem-messages/version.py"
+
+cd "$deployment_dir/"
 tar                                            \
     --create                                   \
     --verbose                                  \


### PR DESCRIPTION
Now github tag to RELEASE-VERSION is set from concent-deployment
repository. We want to get github tag from concent repository.