### PR TITLE
Add the domain name to geth to allow communication by name rather than IP

### DIFF
--- a/kubernetes/services/geth.yml.j2
+++ b/kubernetes/services/geth.yml.j2
@@ -22,8 +22,9 @@ spec:
               # Also remember that geth needs significantly more memory than just cache so don't set it to the same value.
               "--cache",    "512",
               "--rpc",
-              "--rpcaddr",  "0.0.0.0",
-              "--rpcapi",   "eth",
+              "--rpcaddr",    "0.0.0.0",
+              "--rpcvhosts",  "geth, geth.default, geth.default.svc.cluster.local",
+              "--rpcapi",     "eth",
               "--ipcdisable"
           ]
           resources:


### PR DESCRIPTION
To  `v1.8.1` geth version was added DNS rebind protection. To accepting
remote request by name, We must specify `--rpcvhosts=your.domain`.