### PR TITLE
Add `ignore_errors` directive to `Stop postgres container` task

### DIFF
--- a/concent-builder/build-test-and-push.yml
+++ b/concent-builder/build-test-and-push.yml
@@ -85,6 +85,7 @@
       always:
         - name:  Stop postgres container
           shell: docker stop {{ cluster }}-{{ image_prefix }}postgresql-unittest
+          ignore_errors: yes
 
         - name:  Delete custom network
           shell: docker network rm {{ cluster }}-{{ image_prefix }}unittest-network


### PR DESCRIPTION
The ansible `always` directive do not perform second task if first one
occurs errors. We want to be sure that all tasks are always executed.