### PR TITLE
Add missing `CELERY_BROKER_URL` setting to conductor local_settings.py file

### DIFF
--- a/kubernetes/config-maps/conductor/local_settings.py.j2
+++ b/kubernetes/config-maps/conductor/local_settings.py.j2
@@ -46,6 +46,8 @@ RAVEN_CONFIG = {
     'tags': {'component': 'conductor'},
 }
 
+CELERY_BROKER_URL = 'amqp://rabbitmq.default.svc.cluster.local:5672'
+
 EMAIL_SUBJECT_PREFIX = "[{{ gke.cluster }}:conductor] "
 
 CONCENT_FEATURES = ["conductor-urls"]


### PR DESCRIPTION
The `CELERY_BROKER_URL` setting contain address to rabbitmq. Without
this setting, the conductor could not connect to rabbitmq.
Resolves [#499](https://github.com/golemfactory/concent/issues/499)