### PR TITLE
Move `VERIFIER_MIN_SSIM` setting from `base.py` file in concent repository to verifier local_settings.py file

### DIFF
--- a/kubernetes/config-maps/verifier/local_settings.py.j2
+++ b/kubernetes/config-maps/verifier/local_settings.py.j2
@@ -28,6 +28,6 @@ EMAIL_SUBJECT_PREFIX = "[{{ gke.cluster }}:verifier] "
 CELERY_BROKER_URL = 'amqp://rabbitmq.default.svc.cluster.local:5672'
 
 CONCENT_FEATURES = ["verifier"]
-
 STORAGE_SERVER_INTERNAL_ADDRESS = "http://nginx-storage.default.svc.cluster.local"
 VERIFIER_STORAGE_PATH = "/srv/storage/"
+VERIFIER_MIN_SSIM = 0.94


### PR DESCRIPTION
This setting is moved, because it only needed when `CONCENT_FEATURES`
contains verifier app. Second problem is that system check occurs error
when `VERIFIER_MIN_SSIM` is define without enable verifier in
`CONCENT_FEATURES`.

It's depend on [#558](https://github.com/golemfactory/concent/pull/558)