### PR TITLE
Nginx-proxy allow connect to nginx-storage by using https

### DIFF
--- a/kubernetes/config-maps/nginx-proxy/default.conf.j2
+++ b/kubernetes/config-maps/nginx-proxy/default.conf.j2
@@ -53,7 +53,11 @@ server {
     }
 
     location ~ ^/(download|upload)/ {
+        {% if nginx_storage_allow_http %}
         set $nginx_storage_backend http://nginx-storage.default.svc.cluster.local;
+        {% else %}
+        set $nginx_storage_backend https://nginx-storage.default.svc.cluster.local;
+        {% endif %}
         client_max_body_size               {{ max_upload_size }};
         proxy_set_header X-Real-IP         $remote_addr;
         proxy_set_header X-Forwarded-For   $remote_addr;


### PR DESCRIPTION
Now, we use the same self-signed certificate for nginx-proxy and
nginx-storage. The proxy `host` header in nginx-proxy allow to set
server_name as in original request(domain name). This behavior allow to
connect by using https.

Resolves #81 