### PR TITLE
Delete old `deploy_verification` jinja variable that controls deploying verification on the cluster.

### DIFF
--- a/kubernetes/config-maps/concent-api-worker/local_settings.py.j2
+++ b/kubernetes/config-maps/concent-api-worker/local_settings.py.j2
@@ -11,16 +11,18 @@ from ..secrets.secrets import (
     CONCENT_PUBLIC_KEY,
     CONCENT_PRIVATE_KEY,
     SENTRY_DATA_SOURCE_NAME,
+    {% if allow_signing_service_authentication %}
     SIGNING_SERVICE_PUBLIC_KEY,
+    {% else %}
+    CONCENT_ETHEREUM_PRIVATE_KEY,
+    {% endif %}
 )
 
 DEBUG_INFO_IN_ERROR_RESPONSES = {{ allow_debug_info_in_error_responses }}
 
 LOGGING['handlers']['console']['level'] = DEBUG
 
-{% if signing_service_on_the_cluster %}
-USE_SIGNING_SERVICE = True
-{% endif %}
+USE_SIGNING_SERVICE = {{ True if allow_signing_service_authentication else False }}
 
 DATABASES['control']['NAME']     = '{{ control_database_name }}'
 DATABASES['control']['USER']     = '{{ control_database_user }}'

--- a/kubernetes/config-maps/concent-api/local_settings.py.j2
+++ b/kubernetes/config-maps/concent-api/local_settings.py.j2
@@ -11,16 +11,18 @@ from ..secrets.secrets import (
     CONCENT_PUBLIC_KEY,
     CONCENT_PRIVATE_KEY,
     SENTRY_DATA_SOURCE_NAME,
+    {% if allow_signing_service_authentication %}
     SIGNING_SERVICE_PUBLIC_KEY,
+    {% else %}
+    CONCENT_ETHEREUM_PRIVATE_KEY,
+    {% endif %}
 )
 
 DEBUG_INFO_IN_ERROR_RESPONSES = {{ allow_debug_info_in_error_responses }}
 
 LOGGING['handlers']['console']['level'] = DEBUG
 
-{% if signing_service_on_the_cluster %}
-USE_SIGNING_SERVICE = True
-{% endif %}
+USE_SIGNING_SERVICE = {{ True if allow_signing_service_authentication else False }}
 
 DATABASES['control']['NAME']     = '{{ control_database_name }}'
 DATABASES['control']['USER']     = '{{ control_database_user }}'

--- a/kubernetes/config-maps/nginx-proxy/nginx.conf.j2
+++ b/kubernetes/config-maps/nginx-proxy/nginx.conf.j2
@@ -28,6 +28,7 @@ http {
 }
 
 
+{% if allow_signing_service_authentication %}
 # TCP connection
 stream {
 
@@ -39,3 +40,4 @@ stream {
 
     include /etc/nginx/configs/tcp.conf;
 }
+{% endif %}

--- a/kubernetes/create-config-maps.sh.j2
+++ b/kubernetes/create-config-maps.sh.j2
@@ -52,8 +52,10 @@ kubectl create configmap conductor-worker-settings                              
     --from-literal=__init__.py=
 {% endif %}
 
+{% if allow_signing_service_authentication %}
 kubectl create configmap middleman-settings                                \
     --from-file=local_settings.py=config-maps/middleman/local_settings.py  \
     --from-file=email_settings.py=config-maps/concent/email_settings.py    \
     --from-file=timing_settings.py=config-maps/concent/timing_settings.py  \
     --from-literal=__init__.py=
+{% endif %}

--- a/kubernetes/create-config-maps.sh.j2
+++ b/kubernetes/create-config-maps.sh.j2
@@ -19,13 +19,11 @@ kubectl create configmap concent-api-settings                                \
     --from-file=timing_settings.py=config-maps/concent/timing_settings.py    \
     --from-literal=__init__.py=
 
-{% if deploy_verification %}
 kubectl create configmap concent-api-worker-settings                                \
     --from-file=local_settings.py=config-maps/concent-api-worker/local_settings.py  \
     --from-file=email_settings.py=config-maps/concent/email_settings.py             \
     --from-file=timing_settings.py=config-maps/concent/timing_settings.py           \
     --from-literal=__init__.py=
-{% endif %}
 
 kubectl create configmap gatekeeper-settings                               \
     --from-file=local_settings.py=config-maps/gatekeeper/local_settings.py \
@@ -38,7 +36,6 @@ kubectl create configmap conductor-settings                                \
     --from-file=email_settings.py=config-maps/concent/email_settings.py    \
     --from-file=timing_settings.py=config-maps/concent/timing_settings.py  \
 
-{% if deploy_verification %}
 kubectl create configmap verifier-settings                                 \
     --from-file=local_settings.py=config-maps/verifier/local_settings.py   \
     --from-file=email_settings.py=config-maps/concent/email_settings.py    \
@@ -50,7 +47,6 @@ kubectl create configmap conductor-worker-settings                              
     --from-file=email_settings.py=config-maps/concent/email_settings.py           \
     --from-file=timing_settings.py=config-maps/concent/timing_settings.py         \
     --from-literal=__init__.py=
-{% endif %}
 
 {% if allow_signing_service_authentication %}
 kubectl create configmap middleman-settings                                \

--- a/kubernetes/create-services.sh.j2
+++ b/kubernetes/create-services.sh.j2
@@ -8,7 +8,9 @@ kubectl create --record --filename services/verifier.yml
 {% endif %}
 kubectl create --record --filename services/geth.yml
 kubectl create --record --filename services/rabbitmq.yml
+{% if allow_signing_service_authentication %}
 kubectl create --record --filename services/middleman.yml
+{% endif %}
 {% if signing_service_on_the_cluster %}
 kubectl create --record --filename services/signing-service.yml
 {% endif %}
@@ -25,7 +27,9 @@ kubectl create --record --filename services/nginx-storage.yml
 kubectl create --record --filename services/nginx-proxy.yml
 ./wait-until-ready.sh geth                 60
 ./wait-until-ready.sh rabbitmq             60
+{% if allow_signing_service_authentication %}
 ./wait-until-ready.sh middleman            30
+{% endif %}
 {% if signing_service_on_the_cluster %}
 ./wait-until-ready.sh signing-service      30
 {% endif %}

--- a/kubernetes/create-services.sh.j2
+++ b/kubernetes/create-services.sh.j2
@@ -2,10 +2,8 @@
 
 ./create-config-maps.sh
 
-{% if deploy_verification %}
 kubectl create --record --filename services/verifier.yml
 ./wait-until-ready.sh verifier 70
-{% endif %}
 kubectl create --record --filename services/geth.yml
 kubectl create --record --filename services/rabbitmq.yml
 {% if allow_signing_service_authentication %}
@@ -15,14 +13,10 @@ kubectl create --record --filename services/middleman.yml
 kubectl create --record --filename services/signing-service.yml
 {% endif %}
 kubectl create --record --filename services/concent-api.yml
-{% if deploy_verification %}
 kubectl create --record --filename services/concent-api-worker.yml
-{% endif %}
 kubectl create --record --filename services/gatekeeper.yml
 kubectl create --record --filename services/conductor.yml
-{% if deploy_verification %}
 kubectl create --record --filename services/conductor-worker.yml
-{% endif %}
 kubectl create --record --filename services/nginx-storage.yml
 kubectl create --record --filename services/nginx-proxy.yml
 ./wait-until-ready.sh geth                 60
@@ -34,13 +28,9 @@ kubectl create --record --filename services/nginx-proxy.yml
 ./wait-until-ready.sh signing-service      30
 {% endif %}
 ./wait-until-ready.sh concent-api          30
-{% if deploy_verification %}
 ./wait-until-ready.sh concent-api-worker   30
-{% endif %}
 ./wait-until-ready.sh gatekeeper           30
 ./wait-until-ready.sh conductor            30
-{% if deploy_verification %}
 ./wait-until-ready.sh conductor-worker     30
-{% endif %}
 ./wait-until-ready.sh nginx-storage        30
 ./wait-until-ready.sh nginx-proxy          30


### PR DESCRIPTION
We are now always deploying verification, so this variable is no longer
needed.