### PR TITLE
Change installing rustc from testing release

### DIFF
--- a/concent-vm/configure.yml
+++ b/concent-vm/configure.yml
@@ -49,7 +49,6 @@
             - libgmp-dev
             - libfreeimage-dev
             - libtool
-            - rustc
             - cargo
 
         - name:   Install extra dependencies from testing for Golem
@@ -58,6 +57,7 @@
             - python3-pip
             - python3-netifaces
             - python3-psutil
+            - rustc
 
         - name:   Create the user account that will be used for building stuff
           user:


### PR DESCRIPTION
Change the way how rustc is installed because actual version which was installed `1.24.1` is not supported in golems `setup.py` and have to be updated to the newest release which is available only on testing release