### PR TITLE
Fix golem configuration directory creation in Concent VM

### DIFF
--- a/concent-vm/Vagrantfile
+++ b/concent-vm/Vagrantfile
@@ -14,12 +14,15 @@ Vagrant.configure("2") do |config|
 
     # This should be an absolute path because `vboxmanage` fails when used with
     # a relative one on some systems (discovered on Ubuntu xx.xx with Vagrant 2.2.1).
-    golem_configuration_disk = File.expand_path('./disk/golem_configuration_directory.vdi')
+    disk_dir                 = File.expand_path('./disk/')
+    golem_configuration_disk = "#{disk_dir}/golem_configuration_directory.vdi"
 
     config.vm.provider "virtualbox" do |virtualbox|
         virtualbox.memory = 2048
         virtualbox.gui    = false
         if not File.exists?(golem_configuration_disk)
+            FileUtils.mkdir_p(disk_dir)
+
             virtualbox.customize [
                 'createhd',
                 '--filename', golem_configuration_disk,

--- a/concent-vm/Vagrantfile
+++ b/concent-vm/Vagrantfile
@@ -12,7 +12,8 @@ Vagrant.configure("2") do |config|
 
     config.vm.network "private_network", ip: "172.40.2.3"
 
-    # Path must be absolute to work correctly on Ubuntu with Vagrant 2.2.1.
+    # This should be an absolute path because `vboxmanage` fails when used with
+    # a relative one on some systems (discovered on Ubuntu xx.xx with Vagrant 2.2.1).
     golem_configuration_disk = File.expand_path('./disk/golem_configuration_directory.vdi')
 
     config.vm.provider "virtualbox" do |virtualbox|

--- a/concent-vm/Vagrantfile
+++ b/concent-vm/Vagrantfile
@@ -13,15 +13,15 @@ Vagrant.configure("2") do |config|
     config.vm.network "private_network", ip: "172.40.2.3"
 
     # Path must be absolute to work correctly on Ubuntu with Vagrant 2.2.1.
-    golem_configuration_directory = File.expand_path('./disk/golem_configuration_directory.vdi')
+    golem_configuration_disk = File.expand_path('./disk/golem_configuration_directory.vdi')
 
     config.vm.provider "virtualbox" do |virtualbox|
         virtualbox.memory = 2048
         virtualbox.gui    = false
-        if not File.exists?(golem_configuration_directory)
+        if not File.exists?(golem_configuration_disk)
             virtualbox.customize [
                 'createhd',
-                '--filename', golem_configuration_directory,
+                '--filename', golem_configuration_disk,
                 '--variant',  'Fixed',
                 '--size',     1 * 1024, # MB
             ]
@@ -33,12 +33,12 @@ Vagrant.configure("2") do |config|
             '--port',         1,
             '--device',       0,
             '--type',         'hdd',
-            '--medium',       golem_configuration_directory,
+            '--medium',       golem_configuration_disk,
             '--hotpluggable', 'on'
         ]
     end
 
-    if not File.exists?(golem_configuration_directory)
+    if not File.exists?(golem_configuration_disk)
         config.vm.provision "shell", privileged: true, inline: <<-SHELL
             mkfs.ext4 /dev/sdb
         SHELL
@@ -80,13 +80,13 @@ Vagrant.configure("2") do |config|
     end
 
     config.trigger.after :halt do |trigger|
-        detach_virtual_disk(trigger, 1, golem_configuration_directory)
+        detach_virtual_disk(trigger, 1, golem_configuration_disk)
     end
 
     config.trigger.before :destroy do |trigger|
         # `vagrant destroy` normally destroys any virtual disks attached to the machine.
         # Our disk contains Ethereum blockchain which can take a lot of time to redownload so we detach it to prevent its destruction.
-        detach_virtual_disk(trigger, 1, golem_configuration_directory)
+        detach_virtual_disk(trigger, 1, golem_configuration_disk)
     end
 
     config.vm.provision "ansible", run: "always" do |ansible|


### PR DESCRIPTION
Fixes a regression introduced in #323.

`vboxmanage` fails if the `disk/` subdirectory does not exist when the command is executed. As a result it's impossible to create the machine from scratch with `vagrant up`.

There's a bit of refactoring in addition to the fix:
- Fixed the comment mentioned in https://github.com/golemfactory/concent-deployment/pull/323/files#r252697488
- Renamed `golem_configuration_directory` (it's not a directory)