### PR TITLE
Miscellaneous tweaks for Concent VM

### DIFF
--- a/README.md
+++ b/README.md
@@ -487,7 +487,7 @@ ansible-playbook install-golem.yml                                 \
     --inventory   inventory
 ```
 
-`golem_version` parameter determines which branch/tag/commit from the `concent` repository will be deployed in the machine.
+`golem_version` parameter determines which branch/tag/commit from the `golem` repository will be deployed in the machine.
 Version listed in `containers/versions.yml` in `concent-deployment` repository is used by default.
 
 #### Using the machine

--- a/concent-builder/common_tasks/prerequire-configure-tasks.yml
+++ b/concent-builder/common_tasks/prerequire-configure-tasks.yml
@@ -22,8 +22,9 @@
 
 - name:   Add Docker.io apt repository
   apt_repository:
-    repo:  "deb https://apt.dockerproject.org/repo {{ ansible_distribution|lower }}-{{ ansible_distribution_release }} main"
-    state: present
+    repo:         "deb https://apt.dockerproject.org/repo {{ ansible_distribution|lower }}-{{ ansible_distribution_release }} main"
+    state:        present
+    update_cache: no
 
 - name:   Install system updates for Debian
   apt:  update_cache=yes

--- a/concent-builder/common_tasks/prerequire-configure-tasks.yml
+++ b/concent-builder/common_tasks/prerequire-configure-tasks.yml
@@ -26,5 +26,5 @@
     state:        present
     update_cache: no
 
-- name:   Install system updates for Debian
-  apt:  update_cache=yes
+- name:   Update apt package index
+  apt:    update_cache=yes

--- a/concent-vm/Vagrantfile
+++ b/concent-vm/Vagrantfile
@@ -55,16 +55,19 @@ Vagrant.configure("2") do |config|
         partition_name=(
             /dev/sdb
         )
+
         for directory in "${directories[@]}"; do
             if [ ! -d "$directory" ]; then
                 mkdir $directory
             fi
-            mountpoint -q $directory || sudo mount ${partition_name[$index]} $directory
+            mountpoint --quiet $directory || sudo mount ${partition_name[$index]} $directory
             ((index++))
         done
+
         # Create docker group and add your user to it.
-        grep -q docker /etc/group || sudo groupadd docker
-        sudo usermod -aG docker vagrant
+        grep --quiet docker /etc/group || sudo groupadd docker
+        sudo usermod --append --groups docker vagrant
+
         # Change owner of `/home/vagrant/.local/` directory
         sudo chown --recursive vagrant:vagrant /home/vagrant/.local/
     SHELL


### PR DESCRIPTION
A bunch of small commits with tiny improvements:
- Long option names used when running bash commands in `Vagrantfile`
- Minor mistake in `README`
- Ansible's `apt_repository` automatically updates local package index after every call which is unnecessary - we call `apt-get update` aftewards ourselves. Add `update_cache` to disable this behavior.
- Misleading description of a step in one of the playbooks.