### PR TITLE
Delete uploading and manually activating service accounts after assign them to appropriate google compute engine instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,30 +221,12 @@ cd concent-deployment/ethnode/
     --user      $user
 ```
 
-### Authorizing a user account on the build server to access the clusters
-This step must be performed separately for every user of the build server who needs to be able to access other parts of the project infrastructure on Google Cloud with `kubectl` or `gcloud`.
-It can be performed by user himself or an admin who can impersonate him with `sudo`.
+All the instructions below assume that you're using local playbooks to run build and deployment commands on a new server.
 
 The `$cluster` variable determines which server the playbook will be executed on.
 For `concent-dev` it connects to `concent-builder`.
 For other values (`concent-staging`, `concent-testnet` or `concent-mainnet`) - to `concent-deployment-server`.
 This behavior applies to all playbooks, except for `build-test-and-push-containers.yml`.
-
-The `$user_name` variable below indicates the user account to be authorized.
-To perform this step you need to have the .vault files with encrypted secrets in your local `concent-secrets/` directory.
-Only cloud secrets are required in this case.
-Ansible will prompt you for password required to decrypt them.
-
-```bash
-cd concent-deployment/cloud/
-ansible-playbook configure-user-authentication-for-clusters.yml    \
-    --extra-vars "cluster=$cluster user_name=$user_name"           \
-    --ask-vault-pass                                               \
-    --inventory  ../../concent-deployment-values/ansible_inventory \
-    --user       $user
-```
-
-All the instructions below assume that you're using local playbooks to run build and deployment commands on a new server.
 
 Note that if you're running the playbooks themselves from within that server too, you need to add `--connection=local` to your `ansible-playbook` calls.
 Otherwise Ansible will run its commands over SSH (rather than directly) using the public IP specified in `ansible_inventory`, which will likely fail because you're not supposed to have your private SSH key on the remote server you're connecting to.

--- a/cloud/roles/upload_cloud_secrets/tasks/main.yml
+++ b/cloud/roles/upload_cloud_secrets/tasks/main.yml
@@ -20,11 +20,8 @@
 
     - name: Upload secrets
       copy:
-        src:     "{{ local_secret_dir }}/{{ item }}"
-        dest:    "{{ data_dir }}/concent-secrets/{{ item }}"
+        src:     "{{ local_secret_dir }}/cloud/cloud-secrets.yml.vault"
+        dest:    "{{ data_dir }}/concent-secrets/cloud/cloud-secrets.yml"
         decrypt: no
         owner:   "{{ shared_user }}"
         group:   "{{ shared_user }}"
-      with_items:
-        - cloud/{{ gke.service_account_name }}-private-key.json.vault
-        - cloud/cloud-secrets.yml.vault


### PR DESCRIPTION
Resolves #372
It's depends on #378 