### PR TITLE
Add `libffi-dev` package to persistent dependencies after middleman use it

### DIFF
--- a/containers/signing-service/build-dependencies.txt
+++ b/containers/signing-service/build-dependencies.txt
@@ -2,5 +2,4 @@ gcc
 libssl-dev
 git
 pkg-config
-libffi-dev
 software-properties-common

--- a/containers/signing-service/install-dependencies.sh.j2
+++ b/containers/signing-service/install-dependencies.sh.j2
@@ -7,6 +7,7 @@ readarray dependencies <<< $(cat ${BASH_SOURCE%/*}/build-dependencies.txt  ${BAS
 dependencies+=(
     # Package used as runtime dependencies of golem-messages
     libsecp256k1-dev
+    libffi-dev
 )
 
 testing_dependencies=(


### PR DESCRIPTION
Add `libffi-dev` package to persistent dependencies after middleman use it